### PR TITLE
Sped-up random matrix creation

### DIFF
--- a/FB_exp.py
+++ b/FB_exp.py
@@ -18,15 +18,11 @@ def create_random_mat(shape, listidx=None):
     if listidx is None:
         listidx = np.arange(shape[0])
     listidx = listidx[np.random.permutation(len(listidx))]
-    randommat = scipy.sparse.lil_matrix((shape[0], shape[1]),
-            dtype=theano.config.floatX)
-    idx_term = 0
-    for idx_ex in range(shape[1]):
-        if idx_term == len(listidx):
-            idx_term = 0
-        randommat[listidx[idx_term], idx_ex] = 1
-        idx_term += 1
-    return randommat.tocsr()
+    cooData = np.ones(shape[1], dtype=theano.config.floatX)
+    cooRowIdxs = listidx[np.arange(shape[1]) % len(listidx)]
+    cooColIdxs = range(shape[1])
+    randommat = scipy.sparse.coo_matrix((cooData, (cooRowIdxs, cooColIdxs)), shape=shape)
+    return scipy.sparse.csc_matrix(randommat)
 
 
 def load_file(path):

--- a/WN_exp.py
+++ b/WN_exp.py
@@ -18,15 +18,11 @@ def create_random_mat(shape, listidx=None):
     if listidx is None:
         listidx = np.arange(shape[0])
     listidx = listidx[np.random.permutation(len(listidx))]
-    randommat = scipy.sparse.lil_matrix((shape[0], shape[1]),
-            dtype=theano.config.floatX)
-    idx_term = 0
-    for idx_ex in range(shape[1]):
-        if idx_term == len(listidx):
-            idx_term = 0
-        randommat[listidx[idx_term], idx_ex] = 1
-        idx_term += 1
-    return randommat.tocsr()
+    cooData = np.ones(shape[1], dtype=theano.config.floatX)
+    cooRowIdxs = listidx[np.arange(shape[1]) % len(listidx)]
+    cooColIdxs = range(shape[1])
+    randommat = scipy.sparse.coo_matrix((cooData, (cooRowIdxs, cooColIdxs)), shape=shape)
+    return scipy.sparse.csc_matrix(randommat)
 
 
 def load_file(path):


### PR DESCRIPTION
coo_matrix is faster than lil_matrix in create_random_mat

The following code, copied into a fresh ipython session, should verify speed improvement and correctness:

```
import numpy as np
import scipy.sparse
import theano

def cur_crm(shape, listidx=None):
    if listidx is None:
        listidx = np.arange(shape[0])
    listidx = listidx[np.random.permutation(len(listidx))]
    randommat = scipy.sparse.lil_matrix((shape[0], shape[1]),
            dtype=theano.config.floatX)
    idx_term = 0
    for idx_ex in range(shape[1]):
        if idx_term == len(listidx):
            idx_term = 0
        randommat[listidx[idx_term], idx_ex] = 1
        idx_term += 1
    return randommat.tocsr()


def new_crm(shape, listidx=None):
    if listidx is None:
        listidx = np.arange(shape[0])
    listidx = listidx[np.random.permutation(len(listidx))]
    cooData = np.ones(shape[1], dtype=theano.config.floatX)
    cooRowIdxs = listidx[np.arange(shape[1]) % len(listidx)]
    cooColIdxs = range(shape[1])
    randommat = scipy.sparse.coo_matrix((cooData, (cooRowIdxs, cooColIdxs)), shape=shape)
    return scipy.sparse.csc_matrix(randommat)

print "Current random matrix creation, default listidx:"
%timeit cur_crm((40000,1000))

print "\nNew random matrix creation, default listidx:"
%timeit new_crm((40000,1000))

print "\nCurrent random matrix creation, specified (smaller) listidx:"
%timeit cur_crm((40000,1000), np.arange(5000))

print "\nNew random matrix creation, specified (smaller) listidx:"
%timeit new_crm((40000,1000), np.arange(5000))

np.random.seed(123)
a_cur_crm = cur_crm((40000,1000))

np.random.seed(123)
a_new_crm = cur_crm((40000,1000))

assert not np.any((a_cur_crm != a_new_crm).toarray())

np.random.seed(123)
b_cur_crm = cur_crm((40000,1000), np.arange(5000))

np.random.seed(123)
b_new_crm = cur_crm((40000,1000), np.arange(5000))

assert not np.any((b_cur_crm != b_new_crm).toarray())

print "\nNo errors found"
```
